### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ## Neural Tangent Kernel for `scikit-learn` Gaussian Processes
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/392781/scikit-ntk/Lint,%20Build,%20Install,%20Test?label=Lint%2C%20Build%2C%20Install%2C%20Test&style=flat-square) ![PyPI](https://img.shields.io/pypi/v/scikit-ntk?style=flat-square) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/scikit-ntk?style=flat-square)
-
-![PyPI - Downloads](https://img.shields.io/pypi/dm/scikit-ntk?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/392781/scikit-ntk/Lint,%20Build,%20Install,%20Test?label=Lint%2C%20Build%2C%20Install%2C%20Test&style=flat-square) ![PyPI](https://img.shields.io/pypi/v/scikit-ntk?style=flat-square) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/scikit-ntk?style=flat-square) ![PyPI - Downloads](https://img.shields.io/pypi/dm/scikit-ntk?style=flat-square)
 
 **scikit-ntk** is implementation of the neural tangent kernel (NTK) for the `scikit-learn` machine learning library as part of "An Empirical Analysis of the Laplace and Neural Tangent Kernels" master's thesis (found at [http://hdl.handle.net/20.500.12680/d504rr81v](http://hdl.handle.net/20.500.12680/d504rr81v) and [https://arxiv.org/abs/2208.03761](https://arxiv.org/abs/2208.03761)).  This library is meant to directly integrate with [`sklearn.gaussian_process`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.gaussian_process) module.  This implementation of the NTK can be used in combination with other kernels to train and predict with Gaussian process regressors and classifiers. 
 


### PR DESCRIPTION
Minor update to exclude Python 3.11 for now due to upstream dependencies failing to work for the time being as illustrated here: [https://github.com/scikit-learn/scikit-learn/pull/24446](https://github.com/scikit-learn/scikit-learn/pull/24446).