### PR TITLE
1.1.2 - Python 3.11 support added

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         poetry-version: ['1.2.2']
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
 "Bug Tracker" = "https://github.com/392781/scikit-ntk/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7, <3.11"
+python = "^3.7"
 scikit-learn = [
     {version = "^1.0.0", python = ">=3.7,<3.10"},
-    {version = "^1.1", python = ">=3.10"}
+    {version = "^1.1.3", python = ">=3.10"}
 ]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Comes due to scikit-learn release 1.1.3 which includes build wheels for Python 3.11: scikit-learn/scikit-learn#24446.  Resolves #10.